### PR TITLE
fix(renovate): update regex to handle Docker tags with special characters

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
         "/main\\.yml/"
       ],
       "matchStrings": [
-        "#\\s?renovate: image=(?<depName>.*?)\n.+:\\s?(?<currentValue>[\\w+\\.\\-]*)"
+        "#\\s?renovate: image=(?<depName>.*?)\n.+:\\s?(?<currentValue>[^\\s]+)"
       ]
     },
     {


### PR DESCRIPTION
The previous regex pattern `[\w+\.\-]*` was too restrictive and couldn't handle Docker image tags containing slashes (e.g., '31.0.9-apache'). Updated to use `[^\s]+` to match any non-whitespace characters, allowing for proper detection of complex Docker tags.
